### PR TITLE
Expose image channels

### DIFF
--- a/src/ImageLoader.ts
+++ b/src/ImageLoader.ts
@@ -84,6 +84,7 @@ export class ImageLoader extends Loader {
 				data,
 				width: info.width,
 				height: info.height,
+				channels: info.channels,
 			} as unknown as ArrayBuffer))
 			.then(data => {
 


### PR DESCRIPTION
This change comes from the need to save the texture as an image file

In order to save the image from raw data, the width, height and channels information should be provided. This change exposes the channels property to do just that.
