### PR TITLE
GLTFLoader: Support accessors with no bufferView. (#24904)

### DIFF
--- a/src/GLTFLoader.ts
+++ b/src/GLTFLoader.ts
@@ -2493,10 +2493,12 @@ class GLTFParser {
 
 		if ( accessorDef.bufferView === undefined && accessorDef.sparse === undefined ) {
 
-			// Ignore empty accessors, which may be used to declare runtime
-			// information about attributes coming from another source (e.g. Draco
-			// compression extension).
-			return Promise.resolve( null );
+			const itemSize = WEBGL_TYPE_SIZES[ accessorDef.type ];
+			const TypedArray = WEBGL_COMPONENT_TYPES[ accessorDef.componentType ];
+			const normalized = accessorDef.normalized === true;
+
+			const array = new TypedArray( accessorDef.count * itemSize );
+			return Promise.resolve( new BufferAttribute( array, itemSize, normalized ) );
 
 		}
 


### PR DESCRIPTION
https://github.com/mrdoob/three.js/commit/cf753214420a4de0734adc244eda896e4ed2b537