### PR TITLE
replace deprecated LoaderUtils.decodeText() with modern TextDecoder

### DIFF
--- a/src/GLTFLoader.ts
+++ b/src/GLTFLoader.ts
@@ -328,6 +328,7 @@ export class GLTFLoader extends Loader {
 		let content;
 		const extensions = {};
 		const plugins = {};
+		const textDecoder = new TextDecoder();
 
 		if ( typeof data === 'string' ) {
 
@@ -341,7 +342,7 @@ export class GLTFLoader extends Loader {
 
 			}
 
-			const magic = LoaderUtils.decodeText( new Uint8Array( data.slice(0, 4) ) );
+			const magic = textDecoder.decode( new Uint8Array( data.slice(0, 4) ) );
 
 			if ( magic === BINARY_EXTENSION_HEADER_MAGIC ) {
 
@@ -361,7 +362,7 @@ export class GLTFLoader extends Loader {
 
 			} else {
 
-				content = LoaderUtils.decodeText( new Uint8Array( data ) );
+				content = textDecoder.decode( new Uint8Array( data ) );
 
 			}
 
@@ -1434,9 +1435,10 @@ class GLTFBinaryExtension {
 	constructor( data ) {
 
 		const headerView = new DataView( data, 0, BINARY_EXTENSION_HEADER_LENGTH );
+		const textDecoder = new TextDecoder();
 
 		this.header = {
-			magic: LoaderUtils.decodeText( new Uint8Array( data.slice( 0, 4 ) ) ),
+			magic: textDecoder.decode( new Uint8Array( data.slice( 0, 4 ) ) ),
 			version: headerView.getUint32( 4, true ),
 			length: headerView.getUint32( 8, true )
 		};
@@ -1466,7 +1468,7 @@ class GLTFBinaryExtension {
 			if ( chunkType === BINARY_EXTENSION_CHUNK_TYPES.JSON ) {
 
 				const contentArray = new Uint8Array( data, BINARY_EXTENSION_HEADER_LENGTH + chunkIndex, chunkLength );
-				this.content = LoaderUtils.decodeText( contentArray );
+				this.content = textDecoder.decode( contentArray );
 
 			} else if ( chunkType === BINARY_EXTENSION_CHUNK_TYPES.BIN ) {
 


### PR DESCRIPTION
Got this warning on three r172: `THREE.LoaderUtils: decodeText() has been deprecated with r165 and will be removed with r175. Use TextDecoder instead.`

Took changes from three's GLTFLoader regarding TextDecoder.