### PR TITLE
[BUGFIX] load types without changing moduleResolution setting

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
     }
   },
   "type": "module",
+  "types": "build/index.d.ts",
   "engines": {
     "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
   },


### PR DESCRIPTION
Context: 
I'm using Nest js to load and modify gltf files. As such I can't modify the module type in adequation to the moduleResolution asked by the lib because it would break other librairies and Nest module loading.

So i just made types available for typescript without changing the moduleResolution.
I tested it on my Nest app by installing the lib from my fork and it worked.
 `npm install github:lepetitglacon/node-three-gltf#main`

Thanks for the lib !